### PR TITLE
Enables array completion with bracket notation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,3 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
-
-[*.{js,jsx,ts,tsx}]
-ij_javascript_spaces_within_object_literal_braces = true
-ij_typescript_spaces_within_object_literal_braces = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,4 +6,5 @@ end_of_line = lf
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
-
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+
+[*.{js,jsx,ts,tsx}]
+ij_javascript_spaces_within_object_literal_braces = true
+ij_typescript_spaces_within_object_literal_braces = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pro-fa/expr-eval",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pro-fa/expr-eval",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageserver-textdocument": "^1.0.12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pro-fa/expr-eval",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Mathematical expression evaluator",
   "keywords": [
     "expression",

--- a/src/language-service/ls-utils.ts
+++ b/src/language-service/ls-utils.ts
@@ -19,7 +19,8 @@ export function valueTypeName(value: Value): string {
 }
 
 export function isPathChar(ch: string): boolean {
-  return /[A-Za-z0-9_$.]/.test(ch);
+  // Include square brackets to keep array selectors within the detected prefix
+  return /[A-Za-z0-9_$\.\[\]]/.test(ch);
 }
 
 export function extractPathPrefix(text: string, position: number): { start: number; prefix: string } {

--- a/src/language-service/ls-utils.ts
+++ b/src/language-service/ls-utils.ts
@@ -20,7 +20,7 @@ export function valueTypeName(value: Value): string {
 
 export function isPathChar(ch: string): boolean {
   // Include square brackets to keep array selectors within the detected prefix
-  return /[A-Za-z0-9_$\.\[\]]/.test(ch);
+  return /[A-Za-z0-9_$.\[\]]/.test(ch);
 }
 
 export function extractPathPrefix(text: string, position: number): { start: number; prefix: string } {

--- a/src/language-service/variable-utils.ts
+++ b/src/language-service/variable-utils.ts
@@ -171,7 +171,7 @@ function resolveValueByBracketPath(root: unknown, path: string): unknown {
   for (const seg of segments) {
     if (!isObj(node)) return undefined;
     // parse leading name and bracket chains
-    let i = seg.indexOf('[');
+    const i = seg.indexOf('[');
     const name = i >= 0 ? seg.slice(0, i) : seg;
     let rest = i >= 0 ? seg.slice(i) : '';
     if (name) {

--- a/test/language-service/language-service.ts
+++ b/test/language-service/language-service.ts
@@ -29,8 +29,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: {foo: 123, bar: 'test'},
-        position: {line: 0, character: 3}
+        variables: { foo: 123, bar: 'test' },
+        position: { line: 0, character: 3 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('foo');
@@ -41,8 +41,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: {max: 10, min: 5, foo: 1},
-        position: {line: 0, character: 2}
+        variables: { max: 10, min: 5, foo: 1 },
+        position: { line: 0, character: 2 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('max');
@@ -55,8 +55,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: {max: 10, foo: 1},
-        position: {line: 0, character: 2}
+        variables: { max: 10, foo: 1 },
+        position: { line: 0, character: 2 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('max');
@@ -67,8 +67,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: {foo: 1, bar: 2},
-        position: {line: 0, character: 0}
+        variables: { foo: 1, bar: 2 },
+        position: { line: 0, character: 0 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('foo');
@@ -82,7 +82,7 @@ describe('Language Service', () => {
       const completions = ls.getCompletions({
         textDocument: doc,
         variables: undefined,
-        position: {line: 0, character: 3}
+        position: { line: 0, character: 3 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).not.toContain('foo');
@@ -93,7 +93,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: {line: 0, character: 3}
+        position: { line: 0, character: 3 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('sin');
@@ -104,7 +104,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: {line: 0, character: 2}
+        position: { line: 0, character: 2 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('PI');
@@ -115,7 +115,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: {line: 0, character: 2}
+        position: { line: 0, character: 2 }
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('case');
@@ -126,8 +126,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: {foo: {bar: 1}},
-        position: {line: 0, character: 4}
+        variables: { foo: { bar: 1 } },
+        position: { line: 0, character: 4 }
       });
       expect(completions.length).toBeGreaterThan(0);
       const item = completions.find(c => c.label === 'foo.bar');
@@ -140,8 +140,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: {sine: 1},
-        position: {line: 0, character: 2}
+        variables: { sine: 1 },
+        position: { line: 0, character: 2 }
       });
 
       const sinFunc = completions.find(c => c.label === 'sin');
@@ -161,8 +161,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: {myVar: 42},
-        position: {line: 0, character: 2}
+        variables: { myVar: 42 },
+        position: { line: 0, character: 2 }
       });
 
       const varCompletion = completions.find(c => c.label === 'myVar');
@@ -176,7 +176,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: {line: 0, character: 1}
+        position: { line: 0, character: 1 }
       });
 
       const eConst = completions.find(c => c.label === 'E');
@@ -196,7 +196,7 @@ describe('Language Service', () => {
           boolVar: true,
           nullVar: null
         },
-        position: {line: 0, character: 0}
+        position: { line: 0, character: 0 }
       });
 
       expect(completions.find(c => c.label === 'numVar')?.detail).toBe('number');
@@ -215,7 +215,7 @@ describe('Language Service', () => {
         variables: {
           arr: [10, 20, 30]
         },
-        position: {line: 0, character: 3}
+        position: { line: 0, character: 3 }
       });
 
       const arrayItem = completions.find(c => c.label === 'arr[]');
@@ -234,10 +234,10 @@ describe('Language Service', () => {
         textDocument: doc,
         variables: {
           arr: [
-            {foo: 1, bar: 2}
+            { foo: 1, bar: 2 }
           ]
         },
-        position: {line: 0, character: text.length}
+        position: { line: 0, character: text.length }
       });
 
       expect(completions.length).toBeGreaterThan(0);
@@ -256,11 +256,11 @@ describe('Language Service', () => {
         variables: {
           matrix: [
             [
-              {value: 42}
+              { value: 42 }
             ]
           ]
         },
-        position: {line: 0, character: text.length}
+        position: { line: 0, character: text.length }
       });
 
       const valueItem = completions.find(c => c.label === 'matrix[0][1].value');
@@ -277,7 +277,7 @@ describe('Language Service', () => {
         variables: {
           arr: [1, 2, 3]
         },
-        position: {line: 0, character: 3}
+        position: { line: 0, character: 3 }
       });
 
       const arrayItem = completions.find(c => c.label === 'arr[]');
@@ -295,8 +295,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1},
-        variables: {foo: 42}
+        position: { line: 0, character: 1 },
+        variables: { foo: 42 }
       });
 
       const contents = getContentsValue(hover.contents);
@@ -309,7 +309,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1},
+        position: { line: 0, character: 1 },
         variables: {}
       });
 
@@ -322,7 +322,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1},
+        position: { line: 0, character: 1 },
         variables: {}
       });
 
@@ -336,7 +336,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1},
+        position: { line: 0, character: 1 },
         variables: {}
       });
 
@@ -349,7 +349,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 2},
+        position: { line: 0, character: 2 },
         variables: {}
       });
 
@@ -363,7 +363,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1},
+        position: { line: 0, character: 1 },
         variables: {}
       });
 
@@ -376,7 +376,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 2},
+        position: { line: 0, character: 2 },
         variables: {}
       });
 
@@ -389,7 +389,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 0},
+        position: { line: 0, character: 0 },
         variables: {}
       });
 
@@ -401,8 +401,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1},
-        variables: {myFunc: 'my-variable'}
+        position: { line: 0, character: 1 },
+        variables: { myFunc: 'my-variable' }
       });
 
       const contents = getContentsValue(hover.contents);
@@ -416,7 +416,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1}
+        position: { line: 0, character: 1 }
       });
 
       const contents = hover.contents as any;
@@ -434,8 +434,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 1},
-        variables: {foo: 42}
+        position: { line: 0, character: 1 },
+        variables: { foo: 42 }
       });
 
       const contents = hover.contents as any;
@@ -558,13 +558,13 @@ describe('Language Service', () => {
 
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: {line: 0, character: 0}
+        position: { line: 0, character: 0 }
       });
       expect(Array.isArray(completions)).toBe(true);
 
       const hover = ls.getHover({
         textDocument: doc,
-        position: {line: 0, character: 0}
+        position: { line: 0, character: 0 }
       });
       expect(hover).toBeDefined();
 
@@ -602,7 +602,7 @@ describe('Language Service', () => {
 
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: {line: 0, character: text.length}
+        position: { line: 0, character: text.length }
       });
       expect(Array.isArray(completions)).toBe(true);
     });
@@ -613,7 +613,7 @@ describe('Language Service', () => {
 
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: {line: 0, character: 0}
+        position: { line: 0, character: 0 }
       });
       expect(Array.isArray(completions)).toBe(true);
     });
@@ -630,7 +630,7 @@ describe('Language Service', () => {
 
     it('should create service with custom options', () => {
       const service = createLanguageService({
-        operators: {'+': true, '-': false}
+        operators: { '+': true, '-': false }
       });
       expect(service).toBeDefined();
     });

--- a/test/language-service/language-service.ts
+++ b/test/language-service/language-service.ts
@@ -1,7 +1,7 @@
-﻿import { describe, it, expect, beforeEach } from 'vitest';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { createLanguageService } from '../../src/language-service/language-service';
-import { CompletionItemKind, MarkupKind } from 'vscode-languageserver-types';
+﻿import {describe, it, expect, beforeEach} from 'vitest';
+import {TextDocument} from 'vscode-languageserver-textdocument';
+import {createLanguageService} from '../../src/language-service/language-service';
+import {CompletionItemKind, MarkupKind} from 'vscode-languageserver-types';
 
 function getContentsValue(contents: any): string {
   if (typeof contents === 'string') {
@@ -29,8 +29,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: { foo: 123, bar: 'test' },
-        position: { line: 0, character: 3 }
+        variables: {foo: 123, bar: 'test'},
+        position: {line: 0, character: 3}
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('foo');
@@ -41,8 +41,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: { max: 10, min: 5, foo: 1 },
-        position: { line: 0, character: 2 }
+        variables: {max: 10, min: 5, foo: 1},
+        position: {line: 0, character: 2}
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('max');
@@ -55,8 +55,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: { max: 10, foo: 1 },
-        position: { line: 0, character: 2 }
+        variables: {max: 10, foo: 1},
+        position: {line: 0, character: 2}
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('max');
@@ -67,8 +67,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: { foo: 1, bar: 2 },
-        position: { line: 0, character: 0 }
+        variables: {foo: 1, bar: 2},
+        position: {line: 0, character: 0}
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('foo');
@@ -82,7 +82,7 @@ describe('Language Service', () => {
       const completions = ls.getCompletions({
         textDocument: doc,
         variables: undefined,
-        position: { line: 0, character: 3 }
+        position: {line: 0, character: 3}
       });
       const labels = completions.map(c => c.label);
       expect(labels).not.toContain('foo');
@@ -93,7 +93,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: { line: 0, character: 3 }
+        position: {line: 0, character: 3}
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('sin');
@@ -104,7 +104,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: { line: 0, character: 2 }
+        position: {line: 0, character: 2}
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('PI');
@@ -115,7 +115,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: { line: 0, character: 2 }
+        position: {line: 0, character: 2}
       });
       const labels = completions.map(c => c.label);
       expect(labels).toContain('case');
@@ -126,8 +126,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: { foo: { bar: 1 } },
-        position: { line: 0, character: 4 }
+        variables: {foo: {bar: 1}},
+        position: {line: 0, character: 4}
       });
       expect(completions.length).toBeGreaterThan(0);
       const item = completions.find(c => c.label === 'foo.bar');
@@ -140,8 +140,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: { sine: 1 },
-        position: { line: 0, character: 2 }
+        variables: {sine: 1},
+        position: {line: 0, character: 2}
       });
 
       const sinFunc = completions.find(c => c.label === 'sin');
@@ -161,8 +161,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        variables: { myVar: 42 },
-        position: { line: 0, character: 2 }
+        variables: {myVar: 42},
+        position: {line: 0, character: 2}
       });
 
       const varCompletion = completions.find(c => c.label === 'myVar');
@@ -176,7 +176,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: { line: 0, character: 1 }
+        position: {line: 0, character: 1}
       });
 
       const eConst = completions.find(c => c.label === 'E');
@@ -196,98 +196,98 @@ describe('Language Service', () => {
           boolVar: true,
           nullVar: null
         },
-        position: { line: 0, character: 0 }
+        position: {line: 0, character: 0}
       });
 
-            expect(completions.find(c => c.label === 'numVar')?.detail).toBe('number');
-            expect(completions.find(c => c.label === 'strVar')?.detail).toBe('string');
-            expect(completions.find(c => c.label === 'arrVar')?.detail).toBe('array');
-            expect(completions.find(c => c.label === 'boolVar')?.detail).toBe('boolean');
-            expect(completions.find(c => c.label === 'nullVar')?.detail).toBe('null');
-        });
-
-        it('should suggest array selector when variable is an array', () => {
-            const text = 'arr';
-            const doc = TextDocument.create('file://test', 'plaintext', 1, text);
-
-            const completions = ls.getCompletions({
-                textDocument: doc,
-                variables: {
-                    arr: [10, 20, 30]
-                },
-                position: { line: 0, character: 3 }
-            });
-
-            const arrayItem = completions.find(c => c.label === 'arr[]');
-            expect(arrayItem).toBeDefined();
-
-            // Insert only the selector
-            expect(arrayItem?.insertTextFormat).toBe(2); // Snippet
-            expect(arrayItem?.textEdit?.newText).toContain('arr[');
-        });
-
-        it('should autocomplete children after indexed array access', () => {
-            const text = 'arr[0].';
-            const doc = TextDocument.create('file://test', 'plaintext', 1, text);
-
-            const completions = ls.getCompletions({
-                textDocument: doc,
-                variables: {
-                    arr: [
-                        { foo: 1, bar: 2 }
-                    ]
-                },
-                position: { line: 0, character: text.length }
-            });
-
-            expect(completions.length).toBeGreaterThan(0);
-
-            const fooItem = completions.find(c => c.label === 'arr[0].foo');
-            expect(fooItem).toBeDefined();
-            expect(fooItem?.insertText).toBe('foo');
-        });
-
-        it('should support multi-dimensional array selectors', () => {
-            const text = 'matrix[0][1].';
-            const doc = TextDocument.create('file://test', 'plaintext', 1, text);
-
-            const completions = ls.getCompletions({
-                textDocument: doc,
-                variables: {
-                    matrix: [
-                        [
-                            { value: 42 }
-                        ]
-                    ]
-                },
-                position: { line: 0, character: text.length }
-            });
-
-            const valueItem = completions.find(c => c.label === 'matrix[0][1].value');
-            expect(valueItem).toBeDefined();
-            expect(valueItem?.insertText).toBe('value');
-        });
-
-        it('should place cursor inside array brackets', () => {
-            const text = 'arr';
-            const doc = TextDocument.create('file://test', 'plaintext', 1, text);
-
-            const completions = ls.getCompletions({
-                textDocument: doc,
-                variables: {
-                    arr: [1, 2, 3]
-                },
-                position: { line: 0, character: 3 }
-            });
-
-            const arrayItem = completions.find(c => c.label === 'arr[]');
-            const newText = arrayItem?.textEdit?.newText as string | undefined;
-
-            expect(newText).toContain('[');
-            expect(newText).toContain(']');
-            expect(newText).toContain('${1}');
-        });
+      expect(completions.find(c => c.label === 'numVar')?.detail).toBe('number');
+      expect(completions.find(c => c.label === 'strVar')?.detail).toBe('string');
+      expect(completions.find(c => c.label === 'arrVar')?.detail).toBe('array');
+      expect(completions.find(c => c.label === 'boolVar')?.detail).toBe('boolean');
+      expect(completions.find(c => c.label === 'nullVar')?.detail).toBe('null');
     });
+
+    it('should suggest array selector when variable is an array', () => {
+      const text = 'arr';
+      const doc = TextDocument.create('file://test', 'plaintext', 1, text);
+
+      const completions = ls.getCompletions({
+        textDocument: doc,
+        variables: {
+          arr: [10, 20, 30]
+        },
+        position: {line: 0, character: 3}
+      });
+
+      const arrayItem = completions.find(c => c.label === 'arr[]');
+      expect(arrayItem).toBeDefined();
+
+      // Insert only the selector
+      expect(arrayItem?.insertTextFormat).toBe(2); // Snippet
+      expect(arrayItem?.textEdit?.newText).toContain('arr[');
+    });
+
+    it('should autocomplete children after indexed array access', () => {
+      const text = 'arr[0].';
+      const doc = TextDocument.create('file://test', 'plaintext', 1, text);
+
+      const completions = ls.getCompletions({
+        textDocument: doc,
+        variables: {
+          arr: [
+            {foo: 1, bar: 2}
+          ]
+        },
+        position: {line: 0, character: text.length}
+      });
+
+      expect(completions.length).toBeGreaterThan(0);
+
+      const fooItem = completions.find(c => c.label === 'arr[0].foo');
+      expect(fooItem).toBeDefined();
+      expect(fooItem?.insertText).toBe('foo');
+    });
+
+    it('should support multi-dimensional array selectors', () => {
+      const text = 'matrix[0][1].';
+      const doc = TextDocument.create('file://test', 'plaintext', 1, text);
+
+      const completions = ls.getCompletions({
+        textDocument: doc,
+        variables: {
+          matrix: [
+            [
+              {value: 42}
+            ]
+          ]
+        },
+        position: {line: 0, character: text.length}
+      });
+
+      const valueItem = completions.find(c => c.label === 'matrix[0][1].value');
+      expect(valueItem).toBeDefined();
+      expect(valueItem?.insertText).toBe('value');
+    });
+
+    it('should place cursor inside array brackets', () => {
+      const text = 'arr';
+      const doc = TextDocument.create('file://test', 'plaintext', 1, text);
+
+      const completions = ls.getCompletions({
+        textDocument: doc,
+        variables: {
+          arr: [1, 2, 3]
+        },
+        position: {line: 0, character: 3}
+      });
+
+      const arrayItem = completions.find(c => c.label === 'arr[]');
+      const newText = arrayItem?.textEdit?.newText as string | undefined;
+
+      expect(newText).toContain('[');
+      expect(newText).toContain(']');
+      expect(newText).toContain('${1}');
+    });
+  });
 
   describe('getHover', () => {
     it('should show type information for variables', () => {
@@ -295,8 +295,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 },
-        variables: { foo: 42 }
+        position: {line: 0, character: 1},
+        variables: {foo: 42}
       });
 
       const contents = getContentsValue(hover.contents);
@@ -309,7 +309,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 },
+        position: {line: 0, character: 1},
         variables: {}
       });
 
@@ -322,7 +322,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 },
+        position: {line: 0, character: 1},
         variables: {}
       });
 
@@ -336,7 +336,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 },
+        position: {line: 0, character: 1},
         variables: {}
       });
 
@@ -349,7 +349,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 2 },
+        position: {line: 0, character: 2},
         variables: {}
       });
 
@@ -363,7 +363,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 },
+        position: {line: 0, character: 1},
         variables: {}
       });
 
@@ -376,7 +376,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 2 },
+        position: {line: 0, character: 2},
         variables: {}
       });
 
@@ -389,7 +389,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 0 },
+        position: {line: 0, character: 0},
         variables: {}
       });
 
@@ -401,8 +401,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 },
-        variables: { myFunc: 'my-variable' }
+        position: {line: 0, character: 1},
+        variables: {myFunc: 'my-variable'}
       });
 
       const contents = getContentsValue(hover.contents);
@@ -416,7 +416,7 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 }
+        position: {line: 0, character: 1}
       });
 
       const contents = hover.contents as any;
@@ -434,8 +434,8 @@ describe('Language Service', () => {
       const doc = TextDocument.create('file://test', 'plaintext', 1, text);
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 1 },
-        variables: { foo: 42 }
+        position: {line: 0, character: 1},
+        variables: {foo: 42}
       });
 
       const contents = hover.contents as any;
@@ -558,13 +558,13 @@ describe('Language Service', () => {
 
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: { line: 0, character: 0 }
+        position: {line: 0, character: 0}
       });
       expect(Array.isArray(completions)).toBe(true);
 
       const hover = ls.getHover({
         textDocument: doc,
-        position: { line: 0, character: 0 }
+        position: {line: 0, character: 0}
       });
       expect(hover).toBeDefined();
 
@@ -602,7 +602,7 @@ describe('Language Service', () => {
 
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: { line: 0, character: text.length }
+        position: {line: 0, character: text.length}
       });
       expect(Array.isArray(completions)).toBe(true);
     });
@@ -613,7 +613,7 @@ describe('Language Service', () => {
 
       const completions = ls.getCompletions({
         textDocument: doc,
-        position: { line: 0, character: 0 }
+        position: {line: 0, character: 0}
       });
       expect(Array.isArray(completions)).toBe(true);
     });
@@ -630,7 +630,7 @@ describe('Language Service', () => {
 
     it('should create service with custom options', () => {
       const service = createLanguageService({
-        operators: { '+': true, '-': false }
+        operators: {'+': true, '-': false}
       });
       expect(service).toBeDefined();
     });

--- a/test/language-service/language-service.ts
+++ b/test/language-service/language-service.ts
@@ -1,7 +1,7 @@
-﻿import {describe, it, expect, beforeEach} from 'vitest';
-import {TextDocument} from 'vscode-languageserver-textdocument';
-import {createLanguageService} from '../../src/language-service/language-service';
-import {CompletionItemKind, MarkupKind} from 'vscode-languageserver-types';
+﻿import { describe, it, expect, beforeEach } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { createLanguageService } from '../../src/language-service/language-service';
+import { CompletionItemKind, MarkupKind } from 'vscode-languageserver-types';
 
 function getContentsValue(contents: any): string {
   if (typeof contents === 'string') {


### PR DESCRIPTION
Improves auto-completion for variables, specifically when accessing array elements using bracket notation. This allows the language service to suggest completions for array indices.

- Modifies the `isPathChar` function to include square brackets, allowing the detection of array selectors within variable paths.
- Implements a `resolveValueByBracketPath` function to traverse objects using bracket notation.
- Introduces `pushVarKeyCompletions` to suggest array selector snippets (e.g., `[${1}]`) in addition to regular key completions.