### PR TITLE
Handle null in isEmpty and treat it as empty

### DIFF
--- a/src/functions/string/operations.ts
+++ b/src/functions/string/operations.ts
@@ -17,15 +17,19 @@ export function stringLength(str: string | undefined): number | undefined {
 }
 
 /**
- * Checks if a string is empty (length === 0)
+ * Checks if a string is empty (null or length === 0)
  */
-export function isEmpty(str: string | undefined): boolean | undefined {
+export function isEmpty(str: string | null | undefined): boolean | undefined {
   if (str === undefined) {
     return undefined;
+  }  
+  if (str === null) {
+    return true;
   }
   if (typeof str !== 'string') {
     throw new Error('Argument to isEmpty must be a string');
   }
+  
   return str.length === 0;
 }
 

--- a/test/functions/functions-string.ts
+++ b/test/functions/functions-string.ts
@@ -25,6 +25,11 @@ describe('String Functions TypeScript Test', function () {
       assert.strictEqual(parser.evaluate('isEmpty("")'), true);
     });
 
+    it('should return true for null values', function () {
+      const parser = new Parser();
+      assert.strictEqual(parser.evaluate('isEmpty(null)'), true);
+    });
+
     it('should return false for non-empty strings', function () {
       const parser = new Parser();
       assert.strictEqual(parser.evaluate('isEmpty("hello")'), false);


### PR DESCRIPTION
`isEmpty(null)` should return true instead of throwing an error